### PR TITLE
Makefile: add TARGET option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ PREFIX ?= /usr
 INSTALL_DIR ?= $(DESTDIR)$(PREFIX)/lib/lv2
 CXXFLAGS ?= -g -O3
 CXX ?= g++
+TARGET ?= gate_gui.so abGateQt/libabGateQt.so gate.so
 
-$(BUNDLE): manifest.ttl gate.ttl gate.so gate_gui.so bypass_on.png bypass_off.png knob.png background.png abGateQt/libabGateQt.so
+$(BUNDLE): manifest.ttl gate.ttl bypass_on.png bypass_off.png knob.png background.png $(TARGET)
 	rm -rf $(BUNDLE)
 	mkdir $(BUNDLE)
 	cp $^ $(BUNDLE)


### PR DESCRIPTION
This minor contribution allows me to build only a subset of plugins. 
By default all three plugins are built. 
If one user (me) is setting the variable during make invocation, as below, only the LV2 plugin will be built:
```
make TARGET="gate.so"
make install  TARGET="gate.so" 
```
