### PR TITLE
Fix typos in gate.ttl detected by lv2_validate

### DIFF
--- a/gate.ttl
+++ b/gate.ttl
@@ -1,7 +1,7 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
 @prefix doap: <http://usefulinc.com/ns/doap#>.
 @prefix ui: <http://lv2plug.in/ns/extensions/ui#>.
-@prefix units: <http://lv2plug.in/ns/extension/units#>.
+@prefix units: <http://lv2plug.in/ns/extensions/units#>.
 @prefix pprops: <http://lv2plug.in/ns/ext/port-props#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
@@ -21,7 +21,6 @@
 	lv2:binary <gate.so>;
 
 	doap:name "abGate";
-	doap:creator "Antanas Bruzas";
 
 	doap:developer [
 		foaf:name "Antanas Bruzas";


### PR DESCRIPTION
missing 's' in extension*s*
doap:creator does not exist