### PR TITLE
Remove wrong dB to seconds conversion

### DIFF
--- a/gate.ttl
+++ b/gate.ttl
@@ -75,11 +75,6 @@
 	    	lv2:default -70;
 		lv2:portProperty pprops:hasStrictBounds;
 		units:unit units:db;
-		units:conversion [
-			units:to units:s;
-			units:factor 0.001;
-		];
-
 	],
 
 	[


### PR DESCRIPTION
Likely due to copy&paste 1 step too much.
You can't really convert dB to a time unit.
