### PR TITLE
Enable noise-gate by default, map switch to host enable/bypass

### DIFF
--- a/gate.ttl
+++ b/gate.ttl
@@ -60,9 +60,10 @@
 	    	lv2:name "Switch";
 	    	lv2:minimum 0;
 	    	lv2:maximum 1;
-	    	lv2:default 0;
+	    	lv2:default 1;
 		lv2:portProperty pprops:hasStrictBounds;
 		lv2:portProperty lv2:toggled;
+		lv2:designation lv2:enabled;
 	],
 
 	[


### PR DESCRIPTION
Right now the plugin does nothing by default until the user turns on the "switch" parameter.
That makes it confusing to new users.

Also, since the "switch" parameter basically works as on/off switch we can just map it to the host enable/bypass control by the use of right lv2 designation.
